### PR TITLE
Modify autoplay default by taking into account prefers-reduced-motion

### DIFF
--- a/addon/components/lottie.hbs
+++ b/addon/components/lottie.hbs
@@ -1,1 +1,5 @@
-<div ...attributes {{did-insert this.animate}}></div>
+<div
+  ...attributes
+  {{did-insert this.animate}}
+  data-test-autoplay={{if this.autoplay 'true' 'false'}}
+></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "ember-cli-babel": "^7.26.11",
         "ember-cli-htmlbars": "^6.1.0",
         "ember-cli-typescript": "^5.1.0",
+        "ember-window-mock": "^0.8.1",
         "lottie-web": "^5.9.6"
       },
       "devDependencies": {
@@ -42,10 +43,10 @@
         "@types/ember__test-helpers": "^2.6.1",
         "@types/ember__utils": "^4.0.0",
         "@types/ember-qunit": "^5.0.0",
-        "@types/ember-resolver": "^5.0.11",
         "@types/htmlbars-inline-precompile": "^3.0.0",
         "@types/qunit": "^2.19.1",
         "@types/rsvp": "^4.0.4",
+        "@types/sinon": "^10.0.13",
         "babel-eslint": "^10.1.0",
         "broccoli-asset-rev": "^3.0.0",
         "ember-cli": "~4.4.0",
@@ -77,6 +78,7 @@
         "qunit-dom": "^2.0.0",
         "release-it": "^14.2.1",
         "release-it-lerna-changelog": "^3.1.0",
+        "sinon": "^14.0.1",
         "typescript": "^4.7.4",
         "webpack": "^5.72.1"
       },
@@ -2833,6 +2835,41 @@
         "node": ">=6"
       }
     },
+    "node_modules/@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
+      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+      "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
+      "dev": true
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -3266,6 +3303,21 @@
         "@types/mime": "^1",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/sinon": {
+      "version": "10.0.13",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.13.tgz",
+      "integrity": "sha512-UVjDqJblVNQYvVNUsj0PuYYw0ELRmgt1Nt5Vk0pT5f16ROGfcKJY8o1HVuMOJOpD727RrGB9EGvoaTQE5tgxZQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
+      "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
+      "dev": true
     },
     "node_modules/@types/symlink-or-copy": {
       "version": "1.2.0",
@@ -12929,6 +12981,18 @@
         "node": "8.* || >= 10.*"
       }
     },
+    "node_modules/ember-window-mock": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/ember-window-mock/-/ember-window-mock-0.8.1.tgz",
+      "integrity": "sha512-wl9TJuBYFWKsPqDY2gms2jbre1L39AkrPQ9EqbhqHbZI4aEq8u8IZJ0nJaOa7IVr/Jy/kSUXYQGTgvNhz1AzPw==",
+      "dependencies": {
+        "ember-cli-babel": "^7.26.11",
+        "ember-cli-htmlbars": "^6.0.1"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -17113,6 +17177,12 @@
         "node": "*"
       }
     },
+    "node_modules/just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "node_modules/keyv": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -17798,6 +17868,12 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
       "integrity": "sha512-aEXTF4d+m05rVOAUG3z4vZZ4xVexLKZGF0lIxuHZ1Hplpk/3B6Z1+/ICICYRLm7c41Z2xiejbkCkJoTlypoXhQ==",
+      "dev": true
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "node_modules/lodash.isarguments": {
@@ -19185,6 +19261,34 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node_modules/nise": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
+      "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": ">=5",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
+    "node_modules/nise/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
+    },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
     },
     "node_modules/no-case": {
       "version": "3.0.4",
@@ -22679,6 +22783,24 @@
       "integrity": "sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==",
       "dev": true
     },
+    "node_modules/sinon": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.1.tgz",
+      "integrity": "sha512-JhJ0jCiyBWVAHDS+YSjgEbDn7Wgz9iIjA1/RK+eseJN0vAAWIWiXBdrnb92ELPyjsfreCYntD1ORtLSfIrlvSQ==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^9.1.2",
+        "@sinonjs/samsam": "^6.1.1",
+        "diff": "^5.0.0",
+        "nise": "^5.1.1",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -24530,6 +24652,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -28042,6 +28173,41 @@
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
       "dev": true
     },
+    "@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
+      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+      "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
+      "dev": true
+    },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -28469,6 +28635,21 @@
         "@types/mime": "^1",
         "@types/node": "*"
       }
+    },
+    "@types/sinon": {
+      "version": "10.0.13",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.13.tgz",
+      "integrity": "sha512-UVjDqJblVNQYvVNUsj0PuYYw0ELRmgt1Nt5Vk0pT5f16ROGfcKJY8o1HVuMOJOpD727RrGB9EGvoaTQE5tgxZQ==",
+      "dev": true,
+      "requires": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "@types/sinonjs__fake-timers": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
+      "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
+      "dev": true
     },
     "@types/symlink-or-copy": {
       "version": "1.2.0",
@@ -36383,6 +36564,15 @@
         "semver": "^7.3.2"
       }
     },
+    "ember-window-mock": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/ember-window-mock/-/ember-window-mock-0.8.1.tgz",
+      "integrity": "sha512-wl9TJuBYFWKsPqDY2gms2jbre1L39AkrPQ9EqbhqHbZI4aEq8u8IZJ0nJaOa7IVr/Jy/kSUXYQGTgvNhz1AzPw==",
+      "requires": {
+        "ember-cli-babel": "^7.26.11",
+        "ember-cli-htmlbars": "^6.0.1"
+      }
+    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -39619,6 +39809,12 @@
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha512-trvBk1ki43VZptdBI5rIlG4YOzyeH/WefQt5rj1grasPn4iiZWKet8nkgc4GlsAylaztn0qZfUYOiTsASJFdNA=="
     },
+    "just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "keyv": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -40197,6 +40393,12 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
       "integrity": "sha512-aEXTF4d+m05rVOAUG3z4vZZ4xVexLKZGF0lIxuHZ1Hplpk/3B6Z1+/ICICYRLm7c41Z2xiejbkCkJoTlypoXhQ==",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "lodash.isarguments": {
@@ -41362,6 +41564,36 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nise": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
+      "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": ">=5",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "no-case": {
       "version": "3.0.4",
@@ -44099,6 +44331,20 @@
       "integrity": "sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==",
       "dev": true
     },
+    "sinon": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.1.tgz",
+      "integrity": "sha512-JhJ0jCiyBWVAHDS+YSjgEbDn7Wgz9iIjA1/RK+eseJN0vAAWIWiXBdrnb92ELPyjsfreCYntD1ORtLSfIrlvSQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^9.1.2",
+        "@sinonjs/samsam": "^6.1.1",
+        "diff": "^5.0.0",
+        "nise": "^5.1.1",
+        "supports-color": "^7.2.0"
+      }
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -45585,6 +45831,12 @@
       "requires": {
         "prelude-ls": "^1.2.1"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.1.0",
     "ember-cli-typescript": "^5.1.0",
+    "ember-window-mock": "^0.8.1",
     "lottie-web": "^5.9.6"
   },
   "devDependencies": {
@@ -49,8 +50,6 @@
     "@embroider/test-setup": "^1.6.0",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
-    "@types/ember-qunit": "^5.0.0",
-    "@types/ember-resolver": "^5.0.11",
     "@types/ember__application": "^4.0.0",
     "@types/ember__array": "^4.0.1",
     "@types/ember__component": "^4.0.8",
@@ -68,9 +67,11 @@
     "@types/ember__test": "^4.0.0",
     "@types/ember__test-helpers": "^2.6.1",
     "@types/ember__utils": "^4.0.0",
+    "@types/ember-qunit": "^5.0.0",
     "@types/htmlbars-inline-precompile": "^3.0.0",
     "@types/qunit": "^2.19.1",
     "@types/rsvp": "^4.0.4",
+    "@types/sinon": "^10.0.13",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "ember-cli": "~4.4.0",
@@ -102,6 +103,7 @@
     "qunit-dom": "^2.0.0",
     "release-it": "^14.2.1",
     "release-it-lerna-changelog": "^3.1.0",
+    "sinon": "^14.0.1",
     "typescript": "^4.7.4",
     "webpack": "^5.72.1"
   },

--- a/tests/integration/components/lottie-test.ts
+++ b/tests/integration/components/lottie-test.ts
@@ -1,10 +1,14 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, waitFor } from '@ember/test-helpers';
+import { clearRender, render, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import type { TestContext as TestContextBase } from '@ember/test-helpers';
 
 import type { LottieArgs } from '@qonto/ember-lottie/components/lottie';
+
+import window from 'ember-window-mock';
+import { setupWindowMock } from 'ember-window-mock/test-support';
+import * as sinon from 'sinon';
 
 interface TestContext extends TestContextBase {
   args: LottieArgs;
@@ -12,6 +16,7 @@ interface TestContext extends TestContextBase {
 
 module('Integration | Component | lottie', function (hooks) {
   setupRenderingTest(hooks);
+  setupWindowMock(hooks);
 
   hooks.beforeEach(function (this: TestContext) {
     this.args = {
@@ -34,5 +39,144 @@ module('Integration | Component | lottie', function (hooks) {
     await waitFor('svg');
 
     assert.verifySteps(['data ready called']);
+  });
+
+  test('it calls window.matchMedia to check for prefers-reduced-motion', async function (this: TestContext, assert) {
+    window.matchMedia = (mediaQuery) => {
+      assert.step(`matchMedia(${mediaQuery})`);
+      return {
+        addEventListener: sinon.spy(),
+        removeEventListener: sinon.spy(),
+        matches: true,
+      } as unknown as MediaQueryList;
+    };
+
+    await render(hbs`
+      <Lottie
+        @path="/data.json"
+      />
+    `);
+
+    await waitFor('svg');
+    assert.verifySteps([`matchMedia((prefers-reduced-motion: reduce))`]);
+  });
+
+  test('it should listen for changes to prefers-reduced-motion and cleanup the listener when destroyed', async function (this: TestContext, assert) {
+    const addEventListener = sinon.spy();
+    const removeEventListener = sinon.spy();
+    window.matchMedia = () => {
+      return {
+        addEventListener,
+        removeEventListener,
+        matches: true,
+      } as unknown as MediaQueryList;
+    };
+
+    await render(hbs`
+      <Lottie
+        @path="/data.json"
+      />
+    `);
+
+    await waitFor('svg');
+    assert.true(addEventListener.calledOnce);
+
+    await clearRender();
+    assert.true(removeEventListener.calledOnce);
+  });
+
+  test('it should not autoplay the animation when prefers-reduced-motion is enabled', async function (this: TestContext, assert: any) {
+    window.matchMedia = () => {
+      return {
+        addEventListener: () => {
+          /** noop */
+        },
+        removeEventListener: () => {
+          /** noop */
+        },
+        matches: true,
+      } as unknown as MediaQueryList;
+    };
+
+    await render(hbs`
+      <Lottie
+        @path="/data.json"
+        @autoplay={{true}}
+      />
+    `);
+
+    await waitFor('svg');
+    assert.dom('[data-test-autoplay=false]').exists();
+  });
+
+  test('it should not autoplay the animation when autoplay is false', async function (this: TestContext, assert: any) {
+    window.matchMedia = () => {
+      return {
+        addEventListener: () => {
+          /** noop */
+        },
+        removeEventListener: () => {
+          /** noop */
+        },
+        matches: false,
+      } as unknown as MediaQueryList;
+    };
+
+    await render(hbs`
+      <Lottie
+        @path="/data.json"
+        @autoplay={{false}}
+      />
+    `);
+
+    await waitFor('svg');
+    assert.dom('[data-test-autoplay=false]').exists();
+  });
+
+  test('it should autoplay the animation when prefers-reduced-motion is disabled', async function (this: TestContext, assert: any) {
+    window.matchMedia = () => {
+      return {
+        addEventListener: () => {
+          /** noop */
+        },
+        removeEventListener: () => {
+          /** noop */
+        },
+        matches: false,
+      } as unknown as MediaQueryList;
+    };
+
+    await render(hbs`
+      <Lottie
+        @path="/data.json"
+        @autoplay={{true}}
+      />
+    `);
+
+    await waitFor('svg');
+    assert.dom('[data-test-autoplay=true]').exists();
+  });
+
+  test('it should autoplay the animation by default when prefers-reduced-motion is disabled', async function (this: TestContext, assert: any) {
+    window.matchMedia = () => {
+      return {
+        addEventListener: () => {
+          /** noop */
+        },
+        removeEventListener: () => {
+          /** noop */
+        },
+        matches: false,
+      } as unknown as MediaQueryList;
+    };
+
+    await render(hbs`
+      <Lottie
+        @path="/data.json"
+      />
+    `);
+
+    await waitFor('svg');
+    assert.dom('[data-test-autoplay=true]').exists();
   });
 });


### PR DESCRIPTION
👇👇👇
> **WARNING:** the `autoplay` property should be actually renamed to something like `preferredAutoplay` because it can be ignored depending on the value of the `prefers-reduced-motion` media query. I decided to avoid this change now, because it will break existing clients. We can do it on a separate PR

☝️ ☝️ ☝️ 

This PR introduces a default value for the `autoplay` prop, by taking into account the `prefers-reduced-motion` [media query](https://web.dev/prefers-reduced-motion/).

If the host application doesn't specify `@autoplay={{true}}`, the component checks the user preference about motion, if no preference has been given, the component will autoplay the animation; otherwise, if the user prefers reduced motion, the animation won't play. It will follow a similar logic when `@autoplay={{true}}`.

When `@autoplay={{false}}`, the component will never play the animation automatically.

I'm also modifying the visibility of a few class methods/properties to improve the interface.

**Details**: https://web.dev/prefers-reduced-motion/