### PR TITLE
Add ember test waiters waiter in animate function

### DIFF
--- a/addon/components/lottie.ts
+++ b/addon/components/lottie.ts
@@ -1,10 +1,12 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { buildWaiter } from '@ember/test-waiters';
 import Ember from 'ember';
 
 import { AnimationItem, LottiePlayer } from 'lottie-web';
 import window from 'ember-window-mock';
 
+const waiter = buildWaiter('ember-lottie:lottie-waiter');
 class NotFoundError extends Error {
   constructor() {
     super();
@@ -42,6 +44,7 @@ export default class LottieComponent extends Component<LottieArgs> {
 
   @action
   async animate(element: HTMLElement): Promise<void> {
+    const token = waiter.beginAsync();
     const lottie = await this.loadLottie();
     let animationData;
 
@@ -64,6 +67,8 @@ export default class LottieComponent extends Component<LottieArgs> {
             'There was an issue fetching the animation file. Try again.'
           );
         }
+      } finally {
+        waiter.endAsync(token);
       }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@ember/optional-features": "^2.0.0",
         "@ember/render-modifiers": "^2.0.4",
         "@ember/test-helpers": "^2.7.0",
+        "@ember/test-waiters": "^3.0.2",
         "@embroider/test-setup": "^1.6.0",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@ember/optional-features": "^2.0.0",
     "@ember/render-modifiers": "^2.0.4",
     "@ember/test-helpers": "^2.7.0",
+    "@ember/test-waiters": "^3.0.2",
     "@embroider/test-setup": "^1.6.0",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",

--- a/tests/integration/components/lottie-test.ts
+++ b/tests/integration/components/lottie-test.ts
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { clearRender, render, waitFor } from '@ember/test-helpers';
+import { clearRender, find, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import type { TestContext as TestContextBase } from '@ember/test-helpers';
 
@@ -36,8 +36,7 @@ module('Integration | Component | lottie', function (hooks) {
       />
     `);
 
-    await waitFor('svg');
-
+    find('svg');
     assert.verifySteps(['data ready called']);
   });
 
@@ -57,7 +56,7 @@ module('Integration | Component | lottie', function (hooks) {
       />
     `);
 
-    await waitFor('svg');
+    find('svg');
     assert.verifySteps([`matchMedia((prefers-reduced-motion: reduce))`]);
   });
 
@@ -78,7 +77,7 @@ module('Integration | Component | lottie', function (hooks) {
       />
     `);
 
-    await waitFor('svg');
+    find('svg');
     assert.true(addEventListener.calledOnce);
 
     await clearRender();
@@ -105,7 +104,7 @@ module('Integration | Component | lottie', function (hooks) {
       />
     `);
 
-    await waitFor('svg');
+    find('svg');
     assert.dom('[data-test-autoplay=false]').exists();
   });
 
@@ -129,7 +128,7 @@ module('Integration | Component | lottie', function (hooks) {
       />
     `);
 
-    await waitFor('svg');
+    find('svg');
     assert.dom('[data-test-autoplay=false]').exists();
   });
 
@@ -153,7 +152,7 @@ module('Integration | Component | lottie', function (hooks) {
       />
     `);
 
-    await waitFor('svg');
+    find('svg');
     assert.dom('[data-test-autoplay=true]').exists();
   });
 
@@ -176,7 +175,7 @@ module('Integration | Component | lottie', function (hooks) {
       />
     `);
 
-    await waitFor('svg');
+    find('svg');
     assert.dom('[data-test-autoplay=true]').exists();
   });
 });


### PR DESCRIPTION
In this pull request we set up [ember-test-waiters](https://github.com/emberjs/ember-test-waiters) to be able to add a waiter in the `animate` function to wait for async operations to complete before continuing tests.

See. https://github.com/qonto/ember-lottie/issues/20