### PR TITLE
Remove redundant catch block

### DIFF
--- a/addon/components/lottie.ts
+++ b/addon/components/lottie.ts
@@ -59,14 +59,6 @@ export default class LottieComponent extends Component<LottieArgs> {
         } else {
           animationData = await response.json();
         }
-      } catch (error) {
-        if (error instanceof NotFoundError) {
-          throw error;
-        } else {
-          throw new Error(
-            'There was an issue fetching the animation file. Try again.'
-          );
-        }
       } finally {
         waiter.endAsync(token);
       }


### PR DESCRIPTION
We don't want to catch the error in case there's a network error, just to throw a custom error. Let's have the consuming apps handle this.