### PR TITLE
Fixed container option to avoid searching the DOM for undefined containerId

### DIFF
--- a/addon/components/lottie.ts
+++ b/addon/components/lottie.ts
@@ -66,12 +66,17 @@ export default class LottieComponent extends Component<LottieArgs> {
 
     this.args.onDataReady?.();
 
+    const { containerId } = this.args;
+    const container = containerId
+      ? (document.querySelector(`#${containerId}`) as Element)
+      : element;
+
     this.animation = lottie.loadAnimation({
       name: this.args.name,
       loop: this.args.loop,
       autoplay: this.autoplay,
       animationData,
-      container: document.querySelector(`#${this.args.containerId}`) || element,
+      container,
       rendererSettings: {
         progressiveLoad: true,
       },

--- a/tests/integration/components/lottie-test.ts
+++ b/tests/integration/components/lottie-test.ts
@@ -18,12 +18,19 @@ module('Integration | Component | lottie', function (hooks) {
   setupRenderingTest(hooks);
   setupWindowMock(hooks);
 
+  const originalQuerySelector: ParentNode['querySelector'] =
+    document.querySelector;
+
   hooks.beforeEach(function (this: TestContext) {
     this.args = {
       onDataReady: (): void => {
         /* noop */
       },
     };
+  });
+
+  hooks.afterEach(function () {
+    document.querySelector = originalQuerySelector;
   });
 
   test('it renders', async function (this: TestContext, assert) {
@@ -177,5 +184,39 @@ module('Integration | Component | lottie', function (hooks) {
 
     find('svg');
     assert.dom('[data-test-autoplay=true]').exists();
+  });
+
+  test('it should not call document.querySelector when containerId is undefined or null', async function (this: TestContext, assert: any) {
+    const querySelector = sinon.spy();
+    document.querySelector = querySelector;
+    await render(hbs`
+      <Lottie
+        @path="/data.json"
+      />
+    `);
+
+    assert.false(querySelector.calledOnce);
+
+    await render(hbs`
+      <Lottie
+        @path="/data.json"
+        @containerId={{null}}
+      />
+    `);
+
+    assert.false(querySelector.calledOnce);
+  });
+
+  test('it should call document.querySelector when containerId is not falsy', async function (this: TestContext, assert: any) {
+    const querySelector = sinon.spy();
+    document.querySelector = querySelector;
+    await render(hbs`
+      <Lottie
+        @path="/data.json"
+        @containerId='this-is-an-id'
+      />
+    `);
+
+    assert.true(querySelector.calledOnce);
   });
 });


### PR DESCRIPTION
This PR fixes a bug related to the usage of the `containerId` parameter.

If the `containerId` wasn't passed explicitly to the component, then its value would have been `undefined`, which resulted in the DOM searching for an id `#undefined` (passed to `document.querySelector`). 

We want to be sure that when no `containerId` is passed, no call to `document.querySelector` will be done. Wrote a test to make sure that this doesn't happen again.