### PR TITLE
Remove unnecessary jobs in CI script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,6 @@ jobs:
           pnpm-version: 8.5.1
           node-version: 16.x
 
-      - name: Install Dependencies
-        run: pnpm install
-
       - name: Lint
         run: pnpm lint
 
@@ -51,8 +48,6 @@ jobs:
           node-version: 16.x
           no-lockfile: true
 
-      - name: Install Dependencies
-        run: pnpm install
       - name: Run Tests
         run: npm run test:ember
         working-directory: test-app
@@ -84,9 +79,6 @@ jobs:
         with:
           pnpm-version: 8.5.1
           node-version: 16.x
-
-      - name: Install Dependencies
-        run: pnpm install
 
       - name: Run Tests
         run: pnpm try:ember ${{ matrix.try-scenario }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,15 +20,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
-
       - uses: NullVoxPopuli/action-setup-pnpm@v1
         name: Install pnpm
         with:
           pnpm-version: 8.5.1
+          node-version: 16.x
 
       - name: Install Dependencies
         run: pnpm install
@@ -48,15 +44,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
-
       - uses: NullVoxPopuli/action-setup-pnpm@v1
         name: Install pnpm
         with:
           pnpm-version: 8.5.1
+          node-version: 16.x
           no-lockfile: true
 
       - name: Install Dependencies
@@ -87,15 +79,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
-
       - uses: NullVoxPopuli/action-setup-pnpm@v1
         name: Install pnpm
         with:
           pnpm-version: 8.5.1
+          node-version: 16.x
 
       - name: Install Dependencies
         run: pnpm install

--- a/ember-lottie/package.json
+++ b/ember-lottie/package.json
@@ -39,8 +39,12 @@
   },
   "devDependencies": {
     "@babel/core": "7.21.3",
+    "@babel/plugin-proposal-async-generator-functions": "7.20.7",
     "@babel/plugin-proposal-class-properties": "7.18.6",
     "@babel/plugin-proposal-decorators": "7.21.0",
+    "@babel/plugin-proposal-json-strings": "7.18.6",
+    "@babel/plugin-proposal-object-rest-spread": "7.20.7",
+    "@babel/plugin-proposal-optional-catch-binding": "7.18.6",
     "@babel/preset-typescript": "7.21.0",
     "@babel/runtime": "^7.21.0",
     "@embroider/addon-dev": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,12 +44,24 @@ importers:
       '@babel/core':
         specifier: 7.21.3
         version: 7.21.3(supports-color@8.1.1)
+      '@babel/plugin-proposal-async-generator-functions':
+        specifier: 7.20.7
+        version: 7.20.7(@babel/core@7.21.3)
       '@babel/plugin-proposal-class-properties':
         specifier: 7.18.6
         version: 7.18.6(@babel/core@7.21.3)
       '@babel/plugin-proposal-decorators':
         specifier: 7.21.0
         version: 7.21.0(@babel/core@7.21.3)
+      '@babel/plugin-proposal-json-strings':
+        specifier: 7.18.6
+        version: 7.18.6(@babel/core@7.21.3)
+      '@babel/plugin-proposal-object-rest-spread':
+        specifier: 7.20.7
+        version: 7.20.7(@babel/core@7.21.3)
+      '@babel/plugin-proposal-optional-catch-binding':
+        specifier: 7.18.6
+        version: 7.18.6(@babel/core@7.21.3)
       '@babel/preset-typescript':
         specifier: 7.21.0
         version: 7.21.0(@babel/core@7.21.3)


### PR DESCRIPTION
In this MR, we make some updates to our CI script, because we now use `NullVoxPopuli/action-setup-pnpm` and it already:
- handles the node setup (so we were running `actions/setup-node` twice)
- calls `pnpm install` and [expose an `args` input](https://github.com/NullVoxPopuli/action-setup-pnpm#args) (so we were running `pnpm install` command twice)

We had to add some @babel plugins to avoid getting unresolved module errors during the setup.