### PR TITLE
Auto update lock file with dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/test-app" # Location of package manifests
-    schedule:
-      interval: "weekly"
-    # Allow up to 10 open pull requests for pip dependencies
-    open-pull-requests-limit: 10
-
-  - package-ecosystem: "npm"
-    directory: "/ember-lottie" # Location of package manifests
+    directory: "/"
     schedule:
       interval: "weekly"
     # Allow up to 10 open pull requests for pip dependencies


### PR DESCRIPTION
We've got a bunch of dependabot PRs failing due to the lock file not being updated. The issue describes the change to configuration in this PR  https://github.com/dependabot/dependabot-core/issues/4993