### PR TITLE
Update action-setup-pnpm to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: NullVoxPopuli/action-setup-pnpm@v1
+      - uses: wyvox/action-setup-pnpm@v3
         name: Install pnpm
         with:
           pnpm-version: 8.5.1
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: NullVoxPopuli/action-setup-pnpm@v1
+      - uses: wyvox/action-setup-pnpm@v3
         name: Install pnpm
         with:
           pnpm-version: 8.5.1
@@ -74,7 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: NullVoxPopuli/action-setup-pnpm@v1
+      - uses: wyvox/action-setup-pnpm@v3
         name: Install pnpm
         with:
           pnpm-version: 8.5.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,7 +220,7 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2
       '@qonto/ember-lottie':
-        specifier: 0.6.0
+        specifier: 0.6.1
         version: link:../ember-lottie
       '@release-it-plugins/lerna-changelog':
         specifier: ^5.0.0


### PR DESCRIPTION
The aim of this MR is using `wyvox/action-setup-pnpm@v3` in place of `NullVoxPopuli/action-setup-pnpm@v2` in our CI script.

`NullVoxPopuli/action-setup-pnpm` has been [archived](https://github.com/NullVoxPopuli/action-setup-pnpm) and moved to [another repository](https://github.com/wyvox/action-setup-pnpm).