### PR TITLE
feat(dev-deps): upgrade ember-source from ~4.11.0 to ~5.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
         try-scenario:
           - ember-lts-3.28
           - ember-lts-4.4
+          - ember-lts-4.8
+          - ember-lts-4.12
           - ember-release
           - ember-beta
           - ember-canary

--- a/ember-lottie/package.json
+++ b/ember-lottie/package.json
@@ -123,6 +123,6 @@
     }
   },
   "peerDependencies": {
-    "ember-source": "^3.28.0 || ^4.0.0"
+    "ember-source": "^3.28.0 || ^4.0.0 || ^5.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2(@babel/core@7.21.3)
       ember-source:
-        specifier: ^3.28.0 || ^4.0.0
-        version: 4.11.0(@babel/core@7.21.3)(@glimmer/component@1.1.2)(webpack@5.78.0)
+        specifier: ^3.28.0 || ^4.0.0 || ^5.0.0
+        version: 5.3.0(@babel/core@7.21.3)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.78.0)
       ember-window-mock:
         specifier: ^0.8.1
         version: 0.8.1
@@ -149,7 +149,7 @@ importers:
         version: 7.6.0
       ember-modifier:
         specifier: ^4.1.0
-        version: 4.1.0(ember-source@4.11.0)
+        version: 4.1.0(ember-source@5.3.0)
       ember-template-lint:
         specifier: ^4.0.0
         version: 4.18.2
@@ -194,13 +194,13 @@ importers:
         version: 2.0.0
       '@ember/render-modifiers':
         specifier: ^2.0.4
-        version: 2.0.5(@babel/core@7.21.3)(ember-source@4.11.0)
+        version: 2.0.5(@babel/core@7.21.3)(ember-source@5.3.0)
       '@ember/string':
         specifier: ^3.0.1
         version: 3.0.1
       '@ember/test-helpers':
         specifier: ^2.9.3
-        version: 2.9.3(@babel/core@7.21.3)(ember-source@4.11.0)
+        version: 2.9.3(@babel/core@7.21.3)(ember-source@5.3.0)
       '@embroider/compat':
         specifier: ^2.1.1
         version: 2.1.1(@embroider/core@2.1.1)
@@ -248,10 +248,10 @@ importers:
         version: 4.0.2(@babel/core@7.21.3)
       '@types/ember-qunit':
         specifier: ^6.1.1
-        version: 6.1.1(@ember/test-helpers@2.9.3)(ember-source@4.11.0)(qunit@2.19.4)(webpack@5.78.0)
+        version: 6.1.1(@ember/test-helpers@2.9.3)(ember-source@5.3.0)(qunit@2.19.4)(webpack@5.78.0)
       '@types/ember-resolver':
         specifier: ^9.0.0
-        version: 9.0.0(@ember/string@3.0.1)(ember-source@4.11.0)
+        version: 9.0.0(@ember/string@3.0.1)(ember-source@5.3.0)
       '@types/ember__application':
         specifier: ^4.0.5
         version: 4.0.5(@babel/core@7.21.3)
@@ -338,7 +338,7 @@ importers:
         version: 4.11.0
       ember-cli-app-version:
         specifier: ^6.0.0
-        version: 6.0.0(ember-source@4.11.0)
+        version: 6.0.0(ember-source@5.3.0)
       ember-cli-babel:
         specifier: ^7.26.11
         version: 7.26.11
@@ -365,7 +365,7 @@ importers:
         version: 3.0.0
       ember-data:
         specifier: ~4.11.3
-        version: 4.11.3(@babel/core@7.21.3)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@4.11.0)(webpack@5.78.0)
+        version: 4.11.3(@babel/core@7.21.3)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@5.3.0)(webpack@5.78.0)
       ember-disable-prototype-extensions:
         specifier: ^1.1.3
         version: 1.1.3
@@ -377,19 +377,19 @@ importers:
         version: 2.1.2(@babel/core@7.21.3)
       ember-modifier:
         specifier: ^4.1.0
-        version: 4.1.0(ember-source@4.11.0)
+        version: 4.1.0(ember-source@5.3.0)
       ember-page-title:
         specifier: ^7.0.0
         version: 7.0.0
       ember-qunit:
         specifier: ^6.2.0
-        version: 6.2.0(@ember/test-helpers@2.9.3)(ember-source@4.11.0)(qunit@2.19.4)(webpack@5.78.0)
+        version: 6.2.0(@ember/test-helpers@2.9.3)(ember-source@5.3.0)(qunit@2.19.4)(webpack@5.78.0)
       ember-resolver:
         specifier: ^10.0.0
-        version: 10.0.0(@ember/string@3.0.1)(ember-source@4.11.0)
+        version: 10.0.0(@ember/string@3.0.1)(ember-source@5.3.0)
       ember-source:
-        specifier: ~4.11.0
-        version: 4.11.0(@babel/core@7.21.3)(@glimmer/component@1.1.2)(webpack@5.78.0)
+        specifier: ~5.3.0
+        version: 5.3.0(@babel/core@7.21.3)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.78.0)
       ember-source-channel-url:
         specifier: ^3.0.0
         version: 3.0.0
@@ -632,12 +632,6 @@ packages:
 
   /@babel/helper-member-expression-to-functions@7.22.5:
     resolution: {integrity: sha512-aBiH1NKMG0H2cGZqspNvsaBe6wNGjbJjuLy29aU+eDZjSbbN53BaxlpB02xm9v34pLTZ1nIQPFYn2qMZoa5BQQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.22.5
-
-  /@babel/helper-module-imports@7.21.4:
-    resolution: {integrity: sha512-orajc5T2PsRYUN3ZryCEFeMDYwyw09c/pZeaQEZPH0MpKzSvn3e0uXsDBu3k03VI+9DBiRo+l22BfKTpKwa/Wg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.22.5
@@ -912,7 +906,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.3(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.21.3)
 
   /@babel/plugin-proposal-logical-assignment-operators@7.20.7(@babel/core@7.21.3):
@@ -954,7 +948,7 @@ packages:
       '@babel/compat-data': 7.21.4
       '@babel/core': 7.21.3(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.21.4(@babel/core@7.21.3)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.21.3)
       '@babel/plugin-transform-parameters': 7.21.3(@babel/core@7.21.3)
 
@@ -965,7 +959,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.3(supports-color@8.1.1)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.21.3)
 
   /@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.21.3):
@@ -1200,6 +1194,15 @@ packages:
 
   /@babel/plugin-transform-block-scoping@7.21.0(@babel/core@7.21.3):
     resolution: {integrity: sha512-Mdrbunoh9SxwFZapeHVrwFmri16+oYotcZysSzhNIVDwIAb1UV+kvnxULSYq9J3/q5MDG+4X6w8QVgD1zhBXNQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.3(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.22.5
+
+  /@babel/plugin-transform-block-scoping@7.23.0(@babel/core@7.21.3):
+    resolution: {integrity: sha512-cOsrbmIOXmf+5YbL99/S49Y3j46k/T16b9ml8bm9lP6N9US5iQ2yBK7gpui1pg0V/WMcXdkfKbTb7HXq9u+v4g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1773,7 +1776,7 @@ packages:
       ember-inflector: ^4.0.2
     dependencies:
       '@ember-data/private-build-infra': 4.11.3
-      '@ember-data/store': 4.11.3(@babel/core@7.21.3)(@ember-data/model@4.11.3)(@ember-data/record-data@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@4.11.0)(webpack@5.78.0)
+      '@ember-data/store': 4.11.3(@babel/core@7.21.3)(@ember-data/model@4.11.3)(@ember-data/record-data@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@5.3.0)(webpack@5.78.0)
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.0.1
       '@embroider/macros': 1.10.0
@@ -1813,7 +1816,7 @@ packages:
       - webpack
     dev: true
 
-  /@ember-data/model@4.11.3(@babel/core@7.21.3)(@ember-data/record-data@4.11.3)(@ember-data/store@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.0.1)(ember-inflector@4.0.2)(ember-source@4.11.0)(webpack@5.78.0):
+  /@ember-data/model@4.11.3(@babel/core@7.21.3)(@ember-data/record-data@4.11.3)(@ember-data/store@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.0.1)(ember-inflector@4.0.2)(ember-source@5.3.0)(webpack@5.78.0):
     resolution: {integrity: sha512-nkDru5TZmOp4J1xp65D1bR3hBJ3u5KhKKfDpWeGnHW2YDCVUdLORRwW7vfrPnnXDIoJij42DwDVCiTY25Xhrqw==}
     engines: {node: ^14.8.0 || 16.* || >= 18.*}
     peerDependencies:
@@ -1829,13 +1832,13 @@ packages:
       '@ember-data/canary-features': 4.11.3
       '@ember-data/private-build-infra': 4.11.3
       '@ember-data/record-data': 4.11.3(@ember-data/store@4.11.3)(webpack@5.78.0)
-      '@ember-data/store': 4.11.3(@babel/core@7.21.3)(@ember-data/model@4.11.3)(@ember-data/record-data@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@4.11.0)(webpack@5.78.0)
+      '@ember-data/store': 4.11.3(@babel/core@7.21.3)(@ember-data/model@4.11.3)(@ember-data/record-data@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@5.3.0)(webpack@5.78.0)
       '@ember-data/tracking': 4.11.3
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.0.1
       '@embroider/macros': 1.10.0
       ember-auto-import: 2.6.3(webpack@5.78.0)
-      ember-cached-decorator-polyfill: 1.0.1(@babel/core@7.21.3)(ember-source@4.11.0)
+      ember-cached-decorator-polyfill: 1.0.1(@babel/core@7.21.3)(ember-source@5.3.0)
       ember-cli-babel: 7.26.11
       ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
@@ -1854,7 +1857,7 @@ packages:
     engines: {node: ^14.8.0 || 16.* || >= 18.*}
     dependencies:
       '@babel/core': 7.21.3(supports-color@8.1.1)
-      '@babel/plugin-transform-block-scoping': 7.21.0(@babel/core@7.21.3)
+      '@babel/plugin-transform-block-scoping': 7.23.0(@babel/core@7.21.3)
       '@babel/runtime': 7.22.5
       '@ember-data/canary-features': 4.11.3
       '@ember/edition-utils': 1.2.0
@@ -1879,7 +1882,7 @@ packages:
       npm-git-info: 1.0.3
       rimraf: 3.0.2
       rsvp: 4.8.5
-      semver: 7.5.1
+      semver: 7.5.4
       silent-error: 1.1.1
     transitivePeerDependencies:
       - supports-color
@@ -1893,7 +1896,7 @@ packages:
     dependencies:
       '@ember-data/canary-features': 4.11.3
       '@ember-data/private-build-infra': 4.11.3
-      '@ember-data/store': 4.11.3(@babel/core@7.21.3)(@ember-data/model@4.11.3)(@ember-data/record-data@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@4.11.0)(webpack@5.78.0)
+      '@ember-data/store': 4.11.3(@babel/core@7.21.3)(@ember-data/model@4.11.3)(@ember-data/record-data@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@5.3.0)(webpack@5.78.0)
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.10.0
       ember-auto-import: 2.6.3(webpack@5.78.0)
@@ -1915,7 +1918,7 @@ packages:
       ember-inflector: ^4.0.2
     dependencies:
       '@ember-data/private-build-infra': 4.11.3
-      '@ember-data/store': 4.11.3(@babel/core@7.21.3)(@ember-data/model@4.11.3)(@ember-data/record-data@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@4.11.0)(webpack@5.78.0)
+      '@ember-data/store': 4.11.3(@babel/core@7.21.3)(@ember-data/model@4.11.3)(@ember-data/record-data@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@5.3.0)(webpack@5.78.0)
       '@ember/string': 3.0.1
       '@embroider/macros': 1.10.0
       ember-auto-import: 2.6.3(webpack@5.78.0)
@@ -1927,7 +1930,7 @@ packages:
       - webpack
     dev: true
 
-  /@ember-data/store@4.11.3(@babel/core@7.21.3)(@ember-data/model@4.11.3)(@ember-data/record-data@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@4.11.0)(webpack@5.78.0):
+  /@ember-data/store@4.11.3(@babel/core@7.21.3)(@ember-data/model@4.11.3)(@ember-data/record-data@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@5.3.0)(webpack@5.78.0):
     resolution: {integrity: sha512-ogwWy+VqMpkCGs4n30pzuB2vqv/dJRL6wdV3fdNKpXrDugffjuMPpLBQYF937qztDUZKxmnbWAZe5PbQOz8b1Q==}
     engines: {node: ^14.8.0 || 16.* || >= 18.*}
     peerDependencies:
@@ -1943,7 +1946,7 @@ packages:
         optional: true
     dependencies:
       '@ember-data/canary-features': 4.11.3
-      '@ember-data/model': 4.11.3(@babel/core@7.21.3)(@ember-data/record-data@4.11.3)(@ember-data/store@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.0.1)(ember-inflector@4.0.2)(ember-source@4.11.0)(webpack@5.78.0)
+      '@ember-data/model': 4.11.3(@babel/core@7.21.3)(@ember-data/record-data@4.11.3)(@ember-data/store@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.0.1)(ember-inflector@4.0.2)(ember-source@5.3.0)(webpack@5.78.0)
       '@ember-data/private-build-infra': 4.11.3
       '@ember-data/record-data': 4.11.3(@ember-data/store@4.11.3)(webpack@5.78.0)
       '@ember-data/tracking': 4.11.3
@@ -1951,7 +1954,7 @@ packages:
       '@embroider/macros': 1.10.0
       '@glimmer/tracking': 1.1.2
       ember-auto-import: 2.6.3(webpack@5.78.0)
-      ember-cached-decorator-polyfill: 1.0.1(@babel/core@7.21.3)(ember-source@4.11.0)
+      ember-cached-decorator-polyfill: 1.0.1(@babel/core@7.21.3)(ember-source@5.3.0)
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
       - '@babel/core'
@@ -1986,7 +1989,7 @@ packages:
       - supports-color
     dev: true
 
-  /@ember/render-modifiers@2.0.5(@babel/core@7.21.3)(ember-source@4.11.0):
+  /@ember/render-modifiers@2.0.5(@babel/core@7.21.3)(ember-source@5.3.0):
     resolution: {integrity: sha512-5cJ1niIdOJC6k6KtIn9HGbr1DATJQp4ZqMv1vbi6LKQWbVCQ3byvKONtUEi3H0wcewlrcaWCqXOgm0nACzCOQA==}
     engines: {node: 12.* || 14.* || >= 16}
     peerDependencies:
@@ -1995,7 +1998,7 @@ packages:
       '@embroider/macros': 1.10.0
       ember-cli-babel: 7.26.11
       ember-modifier-manager-polyfill: 1.2.0(@babel/core@7.21.3)
-      ember-source: 4.11.0(@babel/core@7.21.3)(@glimmer/component@1.1.2)(webpack@5.78.0)
+      ember-source: 5.3.0(@babel/core@7.21.3)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -2010,7 +2013,7 @@ packages:
       - supports-color
     dev: true
 
-  /@ember/test-helpers@2.9.3(@babel/core@7.21.3)(ember-source@4.11.0):
+  /@ember/test-helpers@2.9.3(@babel/core@7.21.3)(ember-source@5.3.0):
     resolution: {integrity: sha512-ejVg4Dj+G/6zyLvQsYOvmGiOLU6AS94tY4ClaO1E2oVvjjtVJIRmVLFN61I+DuyBg9hS3cFoPjQRTZB9MRIbxQ==}
     engines: {node: 10.* || 12.* || 14.* || 15.* || >= 16.*}
     peerDependencies:
@@ -2018,13 +2021,13 @@ packages:
     dependencies:
       '@ember/test-waiters': 3.0.2
       '@embroider/macros': 1.10.0
-      '@embroider/util': 1.10.0(ember-source@4.11.0)
+      '@embroider/util': 1.10.0(ember-source@5.3.0)
       broccoli-debug: 0.6.5
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.2.0
       ember-destroyable-polyfill: 2.0.3(@babel/core@7.21.3)
-      ember-source: 4.11.0(@babel/core@7.21.3)(@glimmer/component@1.1.2)(webpack@5.78.0)
+      ember-source: 5.3.0(@babel/core@7.21.3)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -2226,7 +2229,7 @@ packages:
       resolve: 1.22.2
     dev: true
 
-  /@embroider/util@1.10.0(ember-source@4.11.0):
+  /@embroider/util@1.10.0(ember-source@5.3.0):
     resolution: {integrity: sha512-utAFKoq6ajI27jyqjvX3PiGL4m+ZyGVlVNbSbE/nOqi2llRyAkh5ltH1WkIK7jhdwQFJouo1NpOSj9J3/HDa3A==}
     engines: {node: 14.* || >= 16}
     peerDependencies:
@@ -2239,7 +2242,7 @@ packages:
       '@embroider/macros': 1.10.0
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
-      ember-source: 4.11.0(@babel/core@7.21.3)(@glimmer/component@1.1.2)(webpack@5.78.0)
+      ember-source: 5.3.0(@babel/core@7.21.3)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.78.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2348,6 +2351,15 @@ packages:
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
     dev: true
 
+  /@glimmer/compiler@0.84.2:
+    resolution: {integrity: sha512-rU8qpqbqxIPwrEQH82yDDFi1hgv6ud1agYexmnmCXlaLS5uCVATJAqKsVozc7aHOgmmF4Ukd/LoF4NYfGr8X3w==}
+    dependencies:
+      '@glimmer/interfaces': 0.84.2
+      '@glimmer/syntax': 0.84.2
+      '@glimmer/util': 0.84.2
+      '@glimmer/wire-format': 0.84.2
+      '@simple-dom/interface': 1.4.0
+
   /@glimmer/component@1.1.2(@babel/core@7.21.3):
     resolution: {integrity: sha512-XyAsEEa4kWOPy+gIdMjJ8XlzA3qrGH55ZDv6nA16ibalCR17k74BI0CztxuRds+Rm6CtbUVgheCVlcCULuqD7A==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -2370,23 +2382,105 @@ packages:
       - '@babel/core'
       - supports-color
 
+  /@glimmer/destroyable@0.84.2:
+    resolution: {integrity: sha512-74L4+jlGUhzhUe87lTxjFdYEEfcDWcza+jqLXoyIb/p4cS0hWsTGlyF+OcuUbHO4yqJd4bXchGOVocoajmSp6w==}
+    dependencies:
+      '@glimmer/env': 0.1.7
+      '@glimmer/global-context': 0.84.2
+      '@glimmer/interfaces': 0.84.2
+      '@glimmer/util': 0.84.2
+
   /@glimmer/di@0.1.11:
     resolution: {integrity: sha512-moRwafNDwHTnTHzyyZC9D+mUSvYrs1Ak0tRPjjmCghdoHHIvMshVbEnwKb/1WmW5CUlKc2eL9rlAV32n3GiItg==}
 
+  /@glimmer/encoder@0.84.2:
+    resolution: {integrity: sha512-599TMDNDHiw+PhNXy5/AnMjh83NBKy+tl2YmwSRY9qktx4DDOZenzgwZ5haLlzPaceejJ6ZNAoGyV5bBrDY5+w==}
+    dependencies:
+      '@glimmer/env': 0.1.7
+      '@glimmer/interfaces': 0.84.2
+      '@glimmer/vm': 0.84.2
+
   /@glimmer/env@0.1.7:
     resolution: {integrity: sha512-JKF/a9I9jw6fGoz8kA7LEQslrwJ5jms5CXhu/aqkBWk+PmZ6pTl8mlb/eJ/5ujBGTiQzBhy5AIWF712iA+4/mw==}
+
+  /@glimmer/global-context@0.84.2:
+    resolution: {integrity: sha512-6FycLh/Eq0P3LA94bJL6WHPJyOTKeQD4KBWhowZ9TbeO3p4/WUr+POKPVEyfIx6YHybhpL9MGj45Y2r0hqVigw==}
+    dependencies:
+      '@glimmer/env': 0.1.7
 
   /@glimmer/global-context@0.84.3:
     resolution: {integrity: sha512-8Oy9Wg5IZxMEeAnVmzD2NkObf89BeHoFSzJgJROE/deutd3rxg83mvlOez4zBBGYwnTb+VGU2LYRpet92egJjA==}
     dependencies:
       '@glimmer/env': 0.1.7
-    dev: true
+
+  /@glimmer/interfaces@0.84.2:
+    resolution: {integrity: sha512-tMZxQpOddUVmHEOuripkNqVR7ba0K4doiYnFd4WyswqoHPlxqpBujbIamQ+bWCWEF0U4yxsXKa31ekS/JHkiBQ==}
+    dependencies:
+      '@simple-dom/interface': 1.4.0
 
   /@glimmer/interfaces@0.84.3:
     resolution: {integrity: sha512-dk32ykoNojt0mvEaIW6Vli5MGTbQo58uy3Epj7ahCgTHmWOKuw/0G83f2UmFprRwFx689YTXG38I/vbpltEjzg==}
     dependencies:
       '@simple-dom/interface': 1.4.0
     dev: true
+
+  /@glimmer/low-level@0.78.2:
+    resolution: {integrity: sha512-0S6TWOOd0fzLLysw1pWZN0TgasaHmYs1Sjz9Til1mTByIXU1S+1rhdyr2veSQPO/aRjPuEQyKXZQHvx23Zax6w==}
+
+  /@glimmer/manager@0.84.2:
+    resolution: {integrity: sha512-cXOnRTH9nwAe/un8hK0x6z1m67Cv5ywAuK7KRxAFTWHgGX/i6BvoZCStr6zJD/U6Frna2c7RJK8JpleP94opEA==}
+    dependencies:
+      '@glimmer/destroyable': 0.84.2
+      '@glimmer/env': 0.1.7
+      '@glimmer/global-context': 0.84.2
+      '@glimmer/interfaces': 0.84.2
+      '@glimmer/reference': 0.84.2
+      '@glimmer/util': 0.84.2
+      '@glimmer/validator': 0.84.2
+
+  /@glimmer/node@0.84.2:
+    resolution: {integrity: sha512-kefGxH+0N0xNyb6QovdPzmIBefZwu8TID45qsASgVbFx7mfFiXjQiyaxbRUyam4MAEb8Nzzx1Byxn1FQCYyLdA==}
+    dependencies:
+      '@glimmer/interfaces': 0.84.2
+      '@glimmer/runtime': 0.84.2
+      '@glimmer/util': 0.84.2
+      '@simple-dom/document': 1.4.0
+      '@simple-dom/interface': 1.4.0
+
+  /@glimmer/opcode-compiler@0.84.2:
+    resolution: {integrity: sha512-KwTH9cWEW4Neu3jmD9ANMIQYBiEqPsLx+h55G+wYp5djyjiYwSJ7KhgMAB+wEHuvB6izp3XdSO6jDMgp3pp49A==}
+    dependencies:
+      '@glimmer/encoder': 0.84.2
+      '@glimmer/env': 0.1.7
+      '@glimmer/interfaces': 0.84.2
+      '@glimmer/reference': 0.84.2
+      '@glimmer/util': 0.84.2
+      '@glimmer/vm': 0.84.2
+      '@glimmer/wire-format': 0.84.2
+
+  /@glimmer/owner@0.84.2:
+    resolution: {integrity: sha512-maZn642eXRImp/hOSa4nQmzMLEIywXwgahS/ZMuzD4HTTsA2SlEdjXSrVbRQYarYF8LkiJ7fpcKHkyNCe8SHrQ==}
+    dependencies:
+      '@glimmer/util': 0.84.2
+
+  /@glimmer/program@0.84.2:
+    resolution: {integrity: sha512-Ohx+7H3+CSVHbC08trUK7fXC6ti9x0SQDC2Lwd7BMXmMyoOZHxdaKNrTJ+CsQ8nV1JkLfXhnvRDG08TqD5VHJw==}
+    dependencies:
+      '@glimmer/encoder': 0.84.2
+      '@glimmer/env': 0.1.7
+      '@glimmer/interfaces': 0.84.2
+      '@glimmer/manager': 0.84.2
+      '@glimmer/opcode-compiler': 0.84.2
+      '@glimmer/util': 0.84.2
+
+  /@glimmer/reference@0.84.2:
+    resolution: {integrity: sha512-hH0VD76OXMsGSHbqaqD64u1aBEqy//jhZtIaHGwAHNpTEX+zDtW3ka298KbAn2CZyDDrNAnuc2U1Vy4COR3zlA==}
+    dependencies:
+      '@glimmer/env': 0.1.7
+      '@glimmer/global-context': 0.84.2
+      '@glimmer/interfaces': 0.84.2
+      '@glimmer/util': 0.84.2
+      '@glimmer/validator': 0.84.2
 
   /@glimmer/reference@0.84.3:
     resolution: {integrity: sha512-lV+p/aWPVC8vUjmlvYVU7WQJsLh319SdXuAWoX/SE3pq340BJlAJiEcAc6q52y9JNhT57gMwtjMX96W5Xcx/qw==}
@@ -2397,6 +2491,31 @@ packages:
       '@glimmer/util': 0.84.3
       '@glimmer/validator': 0.84.3
     dev: true
+
+  /@glimmer/runtime@0.84.2:
+    resolution: {integrity: sha512-mUefYwq8l4df61iWYsRKVYQUqAeCgeZ3fuYNRNbvKDudnT9bQXayJLqr6ZxwTVaDoeKjg+7lMjkDSDSvqoxfsA==}
+    dependencies:
+      '@glimmer/destroyable': 0.84.2
+      '@glimmer/env': 0.1.7
+      '@glimmer/global-context': 0.84.2
+      '@glimmer/interfaces': 0.84.2
+      '@glimmer/low-level': 0.78.2
+      '@glimmer/owner': 0.84.2
+      '@glimmer/program': 0.84.2
+      '@glimmer/reference': 0.84.2
+      '@glimmer/util': 0.84.2
+      '@glimmer/validator': 0.84.2
+      '@glimmer/vm': 0.84.2
+      '@glimmer/wire-format': 0.84.2
+      '@simple-dom/interface': 1.4.0
+
+  /@glimmer/syntax@0.84.2:
+    resolution: {integrity: sha512-SPBd1tpIR9XeaXsXsMRCnKz63eLnIZ0d5G9QC4zIBFBC3pQdtG0F5kWeuRVCdfTIFuR+5WBMfk5jvg+3gbQhjg==}
+    dependencies:
+      '@glimmer/interfaces': 0.84.2
+      '@glimmer/util': 0.84.2
+      '@handlebars/parser': 2.0.0
+      simple-html-tokenizer: 0.5.11
 
   /@glimmer/syntax@0.84.3:
     resolution: {integrity: sha512-ioVbTic6ZisLxqTgRBL2PCjYZTFIwobifCustrozRU2xGDiYvVIL0vt25h2c1ioDsX59UgVlDkIK4YTAQQSd2A==}
@@ -2417,6 +2536,13 @@ packages:
   /@glimmer/util@0.44.0:
     resolution: {integrity: sha512-duAsm30uVK9jSysElCbLyU6QQYO2X9iLDLBIBUcCqck9qN1o3tK2qWiHbGK5d6g8E2AJ4H88UrfElkyaJlGrwg==}
 
+  /@glimmer/util@0.84.2:
+    resolution: {integrity: sha512-VbhzE2s4rmU+qJF3gGBTL1IDjq+/G2Th51XErS8MQVMCmE4CU2pdwSzec8PyOowqCGUOrVIWuMzEI6VoPM4L4w==}
+    dependencies:
+      '@glimmer/env': 0.1.7
+      '@glimmer/interfaces': 0.84.2
+      '@simple-dom/interface': 1.4.0
+
   /@glimmer/util@0.84.3:
     resolution: {integrity: sha512-qFkh6s16ZSRuu2rfz3T4Wp0fylFj3HBsONGXQcrAdZjdUaIS6v3pNj6mecJ71qRgcym9Hbaq/7/fefIwECUiKw==}
     dependencies:
@@ -2429,6 +2555,12 @@ packages:
     resolution: {integrity: sha512-i01plR0EgFVz69GDrEuFgq1NheIjZcyTy3c7q+w7d096ddPVeVcRzU3LKaqCfovvLJ+6lJx40j45ecycASUUyw==}
     dev: true
 
+  /@glimmer/validator@0.84.2:
+    resolution: {integrity: sha512-9tpSmwiktsJDqriNEiFfyP+9prMSdk08THA6Ik71xS/sudBKxoDpul678uvyEYST/+Z23F8MxwKccC+QxCMXNA==}
+    dependencies:
+      '@glimmer/env': 0.1.7
+      '@glimmer/global-context': 0.84.2
+
   /@glimmer/validator@0.84.3:
     resolution: {integrity: sha512-RTBV4TokUB0vI31UC7ikpV7lOYpWUlyqaKV//pRC4pexYMlmqnVhkFrdiimB/R1XyNdUOQUmnIAcdic39NkbhQ==}
     dependencies:
@@ -2436,12 +2568,24 @@ packages:
       '@glimmer/global-context': 0.84.3
     dev: true
 
-  /@glimmer/vm-babel-plugins@0.84.2(@babel/core@7.21.3):
-    resolution: {integrity: sha512-HS2dEbJ3CgXn56wk/5QdudM7rE3vtNMvPIoG7Rrg+GhkGMNxBCIRxOeEF2g520j9rwlA2LAZFpc7MCDMFbTjNA==}
+  /@glimmer/vm-babel-plugins@0.84.3(@babel/core@7.21.3):
+    resolution: {integrity: sha512-fucWuuN7Q9QFB0ODd+PCltcTkmH4fLqYyXGArrfLt/TYN8gLv0yo00mPwFOSY7MWti/MUx88xd20/PycvYtg8w==}
     dependencies:
       babel-plugin-debug-macros: 0.3.4(@babel/core@7.21.3)
     transitivePeerDependencies:
       - '@babel/core'
+
+  /@glimmer/vm@0.84.2:
+    resolution: {integrity: sha512-IuQeDlh+AUOOX8QXc+ehPv5uFnqstQVZGplqqvPQRcKvsEalog88RC34dAEwFdB756SKjgRSw+N+nT3ZDNVlvA==}
+    dependencies:
+      '@glimmer/interfaces': 0.84.2
+      '@glimmer/util': 0.84.2
+
+  /@glimmer/wire-format@0.84.2:
+    resolution: {integrity: sha512-/FmbXSPFJAoIZ6qu28xVXpAdy2Ln++Ewe6mRHFpnudV1lUrBN+Q09A4j/RN/hpAkyz/8ai5W+5rHKuaWxoi4Dg==}
+    dependencies:
+      '@glimmer/interfaces': 0.84.2
+      '@glimmer/util': 0.84.2
 
   /@glint/core@1.1.0(typescript@4.9.5):
     resolution: {integrity: sha512-SeAdKrQF65NRDzzmkwUC0VRZjBDysQXeIKXhyCUtXaatFDeyC0zdESJRcUykMdQoI5R6MKcts2X3gthLRuEGKA==}
@@ -2498,7 +2642,7 @@ packages:
       '@types/ember__controller': 4.0.4(@babel/core@7.21.3)
       '@types/ember__object': 4.0.5(@babel/core@7.21.3)
       '@types/ember__routing': 4.0.12(@babel/core@7.21.3)
-      ember-modifier: 4.1.0(ember-source@4.11.0)
+      ember-modifier: 4.1.0(ember-source@5.3.0)
     dev: true
 
   /@glint/template@1.1.0:
@@ -2507,7 +2651,6 @@ packages:
 
   /@handlebars/parser@2.0.0:
     resolution: {integrity: sha512-EP9uEDZv/L5Qh9IWuMUGJRfwhXJ4h1dqKTT4/3+tY0eu7sPis7xh23j61SYUnNF4vqCQvvUXpDo9Bh/+q1zASA==}
-    dev: true
 
   /@humanwhocodes/config-array@0.11.8:
     resolution: {integrity: sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==}
@@ -2616,7 +2759,7 @@ packages:
     resolution: {integrity: sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==}
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.5.1
+      semver: 7.5.4
     dev: true
 
   /@npmcli/move-file@1.1.2:
@@ -2968,9 +3111,13 @@ packages:
       rollup: 3.23.0
     dev: true
 
+  /@simple-dom/document@1.4.0:
+    resolution: {integrity: sha512-/RUeVH4kuD3rzo5/91+h4Z1meLSLP66eXqpVAw/4aZmYozkeqUkMprq0znL4psX/adEed5cBgiNJcfMz/eKZLg==}
+    dependencies:
+      '@simple-dom/interface': 1.4.0
+
   /@simple-dom/interface@1.4.0:
     resolution: {integrity: sha512-l5qumKFWU0S+4ZzMaLXFU8tQZsicHEMEyAxI5kDFGhJsRqDwe0a7/iPA/GdxlGyDKseQQAgIz5kzU7eXTrlSpA==}
-    dev: true
 
   /@sindresorhus/is@0.14.0:
     resolution: {integrity: sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==}
@@ -3145,11 +3292,11 @@ packages:
       - supports-color
     dev: true
 
-  /@types/ember-qunit@6.1.1(@ember/test-helpers@2.9.3)(ember-source@4.11.0)(qunit@2.19.4)(webpack@5.78.0):
+  /@types/ember-qunit@6.1.1(@ember/test-helpers@2.9.3)(ember-source@5.3.0)(qunit@2.19.4)(webpack@5.78.0):
     resolution: {integrity: sha512-1g5A3vPKhvB/CuN/EP9rBLXYaJOjzKyLYWeBtNDEQNkTuG1dAo/Hg0CCixgbBgLlzaDP8mR/n1xpg8HqQ8SUKg==}
     deprecated: This is a stub types definition. ember-qunit provides its own type definitions, so you do not need this installed.
     dependencies:
-      ember-qunit: 6.2.0(@ember/test-helpers@2.9.3)(ember-source@4.11.0)(qunit@2.19.4)(webpack@5.78.0)
+      ember-qunit: 6.2.0(@ember/test-helpers@2.9.3)(ember-source@5.3.0)(qunit@2.19.4)(webpack@5.78.0)
     transitivePeerDependencies:
       - '@ember/test-helpers'
       - ember-source
@@ -3158,11 +3305,11 @@ packages:
       - webpack
     dev: true
 
-  /@types/ember-resolver@9.0.0(@ember/string@3.0.1)(ember-source@4.11.0):
+  /@types/ember-resolver@9.0.0(@ember/string@3.0.1)(ember-source@5.3.0):
     resolution: {integrity: sha512-lEuC2QD8K6rRAbELMejrALFBgelRPt6OQtapny4Oke07ZtK/Lbf9zn5KIDl7PNkirxMD0AStsQTdUqFu6eVbVw==}
     deprecated: This is a stub types definition. ember-resolver provides its own type definitions, so you do not need this installed.
     dependencies:
-      ember-resolver: 10.0.0(@ember/string@3.0.1)(ember-source@4.11.0)
+      ember-resolver: 10.0.0(@ember/string@3.0.1)(ember-source@5.3.0)
     transitivePeerDependencies:
       - '@ember/string'
       - ember-source
@@ -3722,7 +3869,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.1
+      semver: 7.5.4
       tsutils: 3.21.0(typescript@4.9.5)
       typescript: 4.9.5
     transitivePeerDependencies:
@@ -3743,7 +3890,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.1
+      semver: 7.5.4
       tsutils: 3.21.0(typescript@4.9.5)
       typescript: 4.9.5
     transitivePeerDependencies:
@@ -5002,6 +5149,9 @@ packages:
     dependencies:
       underscore: 1.13.6
     dev: true
+
+  /backburner.js@2.7.0:
+    resolution: {integrity: sha512-eBZC6r7wT+YYAOKeru8IqgzOimz3VgyspXiZ1k6MI8i10zUdU8cnNII56rlnItQ89cHgQO3C/nPuFW3V9di+zg==}
 
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -7045,7 +7195,7 @@ packages:
       parse5: 6.0.1
       resolve: 1.22.2
       resolve-package-path: 4.0.3
-      semver: 7.5.1
+      semver: 7.5.4
       style-loader: 2.0.0(webpack@5.78.0)
       typescript-memoize: 1.1.1
       walk-sync: 3.0.0
@@ -7066,7 +7216,7 @@ packages:
       - supports-color
     dev: true
 
-  /ember-cached-decorator-polyfill@1.0.1(@babel/core@7.21.3)(ember-source@4.11.0):
+  /ember-cached-decorator-polyfill@1.0.1(@babel/core@7.21.3)(ember-source@5.3.0):
     resolution: {integrity: sha512-VDgrpIJ6rDDHIfkYrsFR1BM3fpcC0+zFWIOsX0qY44zPrIXjhQWVXs2iVXLIPHprSgf+tFQ3ESxwDscpeRe/0A==}
     engines: {node: 14.* || >= 16}
     peerDependencies:
@@ -7078,20 +7228,20 @@ packages:
       ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.21.3)
       ember-cli-babel: 7.26.11
       ember-cli-babel-plugin-helpers: 1.1.1
-      ember-source: 4.11.0(@babel/core@7.21.3)(@glimmer/component@1.1.2)(webpack@5.78.0)
+      ember-source: 5.3.0(@babel/core@7.21.3)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.78.0)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
     dev: true
 
-  /ember-cli-app-version@6.0.0(ember-source@4.11.0):
+  /ember-cli-app-version@6.0.0(ember-source@5.3.0):
     resolution: {integrity: sha512-XhzETSTy+RMTIyxM/FaZ/8aJvAwT/iIp8HC9zukpOaSPEm5i6Vm4tskeXY4OBnY3VwFWNXWssDt1hgIkUP76WQ==}
     engines: {node: 14.* || 16.* || >= 18}
     peerDependencies:
       ember-source: ^3.28.0 || ^4.0.0
     dependencies:
       ember-cli-babel: 7.26.11
-      ember-source: 4.11.0(@babel/core@7.21.3)(@glimmer/component@1.1.2)(webpack@5.78.0)
+      ember-source: 5.3.0(@babel/core@7.21.3)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.78.0)
       git-repo-info: 2.1.1
     transitivePeerDependencies:
       - supports-color
@@ -7173,7 +7323,7 @@ packages:
       hash-for-dep: 1.5.1
       heimdalljs-logger: 0.1.10
       json-stable-stringify: 1.0.2
-      semver: 7.5.1
+      semver: 7.5.4
       silent-error: 1.1.1
       strip-bom: 4.0.0
       walk-sync: 2.2.0
@@ -7597,7 +7747,7 @@ packages:
       - '@babel/core'
       - supports-color
 
-  /ember-data@4.11.3(@babel/core@7.21.3)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@4.11.0)(webpack@5.78.0):
+  /ember-data@4.11.3(@babel/core@7.21.3)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@5.3.0)(webpack@5.78.0):
     resolution: {integrity: sha512-7vir6Re3M3M6yJoCHy6UxEg3oSY1JEnsuTByY3lJquWPaUamn7qbPQvNr16Tqh8EKrt+e/+X26czFm4kRGhpVg==}
     engines: {node: ^14.8.0 || 16.* || >= 18.*}
     peerDependencies:
@@ -7605,11 +7755,11 @@ packages:
     dependencies:
       '@ember-data/adapter': 4.11.3(@ember-data/store@4.11.3)(@ember/string@3.0.1)(ember-inflector@4.0.2)(webpack@5.78.0)
       '@ember-data/debug': 4.11.3(@ember/string@3.0.1)(webpack@5.78.0)
-      '@ember-data/model': 4.11.3(@babel/core@7.21.3)(@ember-data/record-data@4.11.3)(@ember-data/store@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.0.1)(ember-inflector@4.0.2)(ember-source@4.11.0)(webpack@5.78.0)
+      '@ember-data/model': 4.11.3(@babel/core@7.21.3)(@ember-data/record-data@4.11.3)(@ember-data/store@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.0.1)(ember-inflector@4.0.2)(ember-source@5.3.0)(webpack@5.78.0)
       '@ember-data/private-build-infra': 4.11.3
       '@ember-data/record-data': 4.11.3(@ember-data/store@4.11.3)(webpack@5.78.0)
       '@ember-data/serializer': 4.11.3(@ember-data/store@4.11.3)(@ember/string@3.0.1)(ember-inflector@4.0.2)(webpack@5.78.0)
-      '@ember-data/store': 4.11.3(@babel/core@7.21.3)(@ember-data/model@4.11.3)(@ember-data/record-data@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@4.11.0)(webpack@5.78.0)
+      '@ember-data/store': 4.11.3(@babel/core@7.21.3)(@ember-data/model@4.11.3)(@ember-data/record-data@4.11.3)(@ember-data/tracking@4.11.3)(@ember/string@3.0.1)(@glimmer/tracking@1.1.2)(ember-source@5.3.0)(webpack@5.78.0)
       '@ember-data/tracking': 4.11.3
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.0.1
@@ -7699,7 +7849,7 @@ packages:
       - supports-color
     dev: true
 
-  /ember-modifier@4.1.0(ember-source@4.11.0):
+  /ember-modifier@4.1.0(ember-source@5.3.0):
     resolution: {integrity: sha512-YFCNpEYj6jdyy3EjslRb2ehNiDvaOrXTilR9+ngq+iUqSHYto2zKV0rleiA1XJQ27ELM1q8RihT29U6Lq5EyqQ==}
     peerDependencies:
       ember-source: '*'
@@ -7710,7 +7860,7 @@ packages:
       '@embroider/addon-shim': 1.8.4
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-string-utils: 1.1.0
-      ember-source: 4.11.0(@babel/core@7.21.3)(@glimmer/component@1.1.2)(webpack@5.78.0)
+      ember-source: 5.3.0(@babel/core@7.21.3)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.78.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7724,7 +7874,7 @@ packages:
       - supports-color
     dev: true
 
-  /ember-qunit@6.2.0(@ember/test-helpers@2.9.3)(ember-source@4.11.0)(qunit@2.19.4)(webpack@5.78.0):
+  /ember-qunit@6.2.0(@ember/test-helpers@2.9.3)(ember-source@5.3.0)(qunit@2.19.4)(webpack@5.78.0):
     resolution: {integrity: sha512-mC+0bp8DwWzJLn8SW3GS8KDZIkl4yLsNYwMi5Dw6+aFllq7FM2crd/dfY4MuOIHK7GKdjtmWJTMGnjSpeSayaw==}
     engines: {node: 14.* || 16.* || >= 18}
     peerDependencies:
@@ -7732,14 +7882,14 @@ packages:
       ember-source: '>=3.28'
       qunit: ^2.13.0
     dependencies:
-      '@ember/test-helpers': 2.9.3(@babel/core@7.21.3)(ember-source@4.11.0)
+      '@ember/test-helpers': 2.9.3(@babel/core@7.21.3)(ember-source@5.3.0)
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 3.0.2
       common-tags: 1.8.2
       ember-auto-import: 2.6.3(webpack@5.78.0)
       ember-cli-babel: 7.26.11
       ember-cli-test-loader: 3.0.0
-      ember-source: 4.11.0(@babel/core@7.21.3)(@glimmer/component@1.1.2)(webpack@5.78.0)
+      ember-source: 5.3.0(@babel/core@7.21.3)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.78.0)
       qunit: 2.19.4
       resolve-package-path: 4.0.3
       silent-error: 1.1.1
@@ -7749,7 +7899,7 @@ packages:
       - webpack
     dev: true
 
-  /ember-resolver@10.0.0(@ember/string@3.0.1)(ember-source@4.11.0):
+  /ember-resolver@10.0.0(@ember/string@3.0.1)(ember-source@5.3.0):
     resolution: {integrity: sha512-e99wFJ4ZpleJ6JMEcIk4WEYP4s3nc+9/iNSXtwBHXC8ADJHJTeN3HjnT/eEbFbswdui4FYxIYuK+UCdP09811Q==}
     engines: {node: 14.* || 16.* || >= 18}
     peerDependencies:
@@ -7761,7 +7911,7 @@ packages:
     dependencies:
       '@ember/string': 3.0.1
       ember-cli-babel: 7.26.11
-      ember-source: 4.11.0(@babel/core@7.21.3)(@glimmer/component@1.1.2)(webpack@5.78.0)
+      ember-source: 5.3.0(@babel/core@7.21.3)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.78.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7789,19 +7939,35 @@ packages:
       - encoding
     dev: true
 
-  /ember-source@4.11.0(@babel/core@7.21.3)(@glimmer/component@1.1.2)(webpack@5.78.0):
-    resolution: {integrity: sha512-SNRHsQOvF3C9emS7Rg4zcFdwY6aiSkV/7CG+KBpmzLY6hIWQNruzEDZINpNgqBn7CicAJ6g573WG7zu6458agQ==}
-    engines: {node: '>= 14.*'}
+  /ember-source@5.3.0(@babel/core@7.21.3)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.78.0):
+    resolution: {integrity: sha512-MnsPEYo2gArYzlY0uu5bBH60oNYcgcayYQEd27nJumuaceN1sMLMu1jGQmjiQzZ4b6U5edEUNQbCIZ/9TXbASw==}
+    engines: {node: '>= 16.*'}
     peerDependencies:
       '@glimmer/component': ^1.1.2
     dependencies:
-      '@babel/helper-module-imports': 7.21.4
-      '@babel/plugin-transform-block-scoping': 7.21.0(@babel/core@7.21.3)
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/plugin-transform-block-scoping': 7.23.0(@babel/core@7.21.3)
       '@ember/edition-utils': 1.2.0
+      '@glimmer/compiler': 0.84.2
       '@glimmer/component': 1.1.2(@babel/core@7.21.3)
-      '@glimmer/vm-babel-plugins': 0.84.2(@babel/core@7.21.3)
+      '@glimmer/destroyable': 0.84.2
+      '@glimmer/env': 0.1.7
+      '@glimmer/global-context': 0.84.3
+      '@glimmer/interfaces': 0.84.2
+      '@glimmer/manager': 0.84.2
+      '@glimmer/node': 0.84.2
+      '@glimmer/opcode-compiler': 0.84.2
+      '@glimmer/owner': 0.84.2
+      '@glimmer/program': 0.84.2
+      '@glimmer/reference': 0.84.2
+      '@glimmer/runtime': 0.84.2
+      '@glimmer/syntax': 0.84.2
+      '@glimmer/validator': 0.84.2
+      '@glimmer/vm-babel-plugins': 0.84.3(@babel/core@7.21.3)
+      '@simple-dom/interface': 1.4.0
       babel-plugin-debug-macros: 0.3.4(@babel/core@7.21.3)
       babel-plugin-filter-imports: 4.0.0
+      backburner.js: 2.7.0
       broccoli-concat: 4.2.5
       broccoli-debug: 0.6.5
       broccoli-file-creator: 2.1.1
@@ -7818,12 +7984,15 @@ packages:
       ember-cli-typescript-blueprint-polyfill: 0.1.0
       ember-cli-version-checker: 5.1.2
       ember-router-generator: 2.0.0
-      inflection: 1.13.4
+      inflection: 2.0.1
       resolve: 1.22.2
-      semver: 7.4.0
+      route-recognizer: 0.3.4
+      router_js: 8.0.3(route-recognizer@0.3.4)(rsvp@4.8.5)
+      semver: 7.5.4
       silent-error: 1.1.1
     transitivePeerDependencies:
       - '@babel/core'
+      - rsvp
       - supports-color
       - webpack
 
@@ -10058,11 +10227,11 @@ packages:
   /inflection@1.13.4:
     resolution: {integrity: sha512-6I/HUDeYFfuNCVS3td055BaXBwKYuzw7K3ExVMStBowKo9oOAMJIXIHvdyR3iboTCp1b+1i5DSkIZTcwIktuDw==}
     engines: {'0': node >= 0.4.0}
+    dev: true
 
   /inflection@2.0.1:
     resolution: {integrity: sha512-wzkZHqpb4eGrOKBl34xy3umnYHx8Si5R1U4fwmdxLo5gdH6mEK8gclckTj/qWqy4Je0bsDYe/qazZYuO7xe3XQ==}
     engines: {node: '>=14.0.0'}
-    dev: true
 
   /inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -12026,7 +12195,7 @@ packages:
     dependencies:
       growly: 1.3.0
       is-wsl: 2.2.0
-      semver: 7.5.1
+      semver: 7.5.4
       shellwords: 0.1.1
       uuid: 8.3.2
       which: 2.0.2
@@ -12509,7 +12678,7 @@ packages:
       got: 12.6.0
       registry-auth-token: 5.0.2
       registry-url: 6.0.1
-      semver: 7.5.1
+      semver: 7.5.4
     dev: true
 
   /parent-module@1.0.1:
@@ -13580,6 +13749,20 @@ packages:
       fsevents: 2.3.2
     dev: true
 
+  /route-recognizer@0.3.4:
+    resolution: {integrity: sha512-2+MhsfPhvauN1O8KaXpXAOfR/fwe8dnUXVM+xw7yt40lJRfPVQxV6yryZm0cgRvAj5fMF/mdRZbL2ptwbs5i2g==}
+
+  /router_js@8.0.3(route-recognizer@0.3.4)(rsvp@4.8.5):
+    resolution: {integrity: sha512-lSgNMksk/wp8nspLX3Pn6QD499FUjwYMkgP99RxqKEScil4DKC/59YezpEZ318zGtkq8WR01VBhH+/u3InlLgg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      route-recognizer: ^0.3.4
+      rsvp: ^4.8.5
+    dependencies:
+      '@glimmer/env': 0.1.7
+      route-recognizer: 0.3.4
+      rsvp: 4.8.5
+
   /rsvp@3.2.1:
     resolution: {integrity: sha512-Rf4YVNYpKjZ6ASAmibcwTNciQ5Co5Ztq6iZPEykHpkoflnD/K5ryE/rHehFsTm4NJj8nKDhbi3eKBWGogmNnkg==}
 
@@ -13740,7 +13923,7 @@ packages:
     resolution: {integrity: sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==}
     engines: {node: '>=12'}
     dependencies:
-      semver: 7.5.1
+      semver: 7.5.4
     dev: true
 
   /semver@5.7.1:
@@ -13787,7 +13970,6 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
-    dev: true
 
   /send@0.18.0:
     resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
@@ -13908,7 +14090,6 @@ packages:
 
   /simple-html-tokenizer@0.5.11:
     resolution: {integrity: sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==}
-    dev: true
 
   /sinon@15.1.0:
     resolution: {integrity: sha512-cS5FgpDdE9/zx7no8bxROHymSlPLZzq0ChbbLk1DrxBfc+eTeBK3y8nIL+nu/0QeYydhhbLIr7ecHJpywjQaoQ==}

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -24,6 +24,22 @@ module.exports = async function () {
         },
       },
       {
+        name: 'ember-lts-4.8',
+        npm: {
+          devDependencies: {
+            'ember-source': '~4.8.0',
+          },
+        },
+      },
+      {
+        name: 'ember-lts-4.12',
+        npm: {
+          devDependencies: {
+            'ember-source': '~4.12.0',
+          },
+        },
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -93,7 +93,7 @@
     "ember-page-title": "^7.0.0",
     "ember-qunit": "^6.2.0",
     "ember-resolver": "^10.0.0",
-    "ember-source": "~4.11.0",
+    "ember-source": "~5.3.0",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^5.6.0",
     "ember-try": "^2.0.0",


### PR DESCRIPTION
In this MR, `ember-source` was bumped from from version ~4.11.0 to ~5.3.0.

Testing scenarios were updated with the relevant LTS versions.