### PR TITLE
chore(deps-dev): bump eslint-plugin-ember from 10.6.1 to 11.11.1 in /ember-lottie

### DIFF
--- a/ember-lottie/package.json
+++ b/ember-lottie/package.json
@@ -82,7 +82,7 @@
     "ember-template-lint": "^4.0.0",
     "eslint": "^8.50.0",
     "eslint-config-prettier": "^8.3.0",
-    "eslint-plugin-ember": "^10.5.8",
+    "eslint-plugin-ember": "^11.11.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.0.0",
     "prettier": "^2.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,8 +160,8 @@ importers:
         specifier: ^8.3.0
         version: 8.8.0(eslint@8.50.0)
       eslint-plugin-ember:
-        specifier: ^10.5.8
-        version: 10.6.1(eslint@8.50.0)
+        specifier: ^11.11.1
+        version: 11.11.1(eslint@8.50.0)
       eslint-plugin-node:
         specifier: ^11.1.0
         version: 11.1.0(eslint@8.50.0)
@@ -8409,21 +8409,28 @@ packages:
     resolution: {integrity: sha512-Uk/TVLt6Nf6Xoz7C1iYuZjOSdJxe5aaauGRke8JhKeJwD66Y61/pY2FjtLP04Ooq9PwV34bzrkKkU2UZ5FtDRA==}
     dev: true
 
-  /eslint-plugin-ember@10.6.1(eslint@8.50.0):
-    resolution: {integrity: sha512-R+TN3jwhYQ2ytZCA1VkfJDZSGgHFOHjsHU1DrBlRXYRepThe56PpuGxywAyDvQ7inhoAz3e6G6M60PzpvjzmNg==}
-    engines: {node: 10.* || 12.* || >= 14}
+  /eslint-plugin-ember@11.11.1(eslint@8.50.0):
+    resolution: {integrity: sha512-dvsDa4LkDkGqCE2bzBIguRMi1g40JVwRWMSHmn8S7toRDxSOU3M7yromgi5eSAJX2O2vEvJZ9QnR15YDbvNfVQ==}
+    engines: {node: 14.* || 16.* || >= 18}
     peerDependencies:
-      eslint: '>= 6'
+      eslint: '>= 7'
     dependencies:
       '@ember-data/rfc395-data': 0.0.4
+      '@glimmer/syntax': 0.84.3
       css-tree: 2.3.1
       ember-rfc176-data: 0.3.18
+      ember-template-imports: 3.4.2
+      ember-template-recast: 6.1.4
       eslint: 8.50.0
       eslint-utils: 3.0.0(eslint@8.50.0)
       estraverse: 5.3.0
+      lodash.camelcase: 4.3.0
       lodash.kebabcase: 4.1.1
+      magic-string: 0.30.0
       requireindex: 1.2.0
       snake-case: 3.0.4
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /eslint-plugin-ember@11.5.1(eslint@8.50.0):


### PR DESCRIPTION
The aim of this PR is bumping [eslint-plugin-ember](https://www.npmjs.com/package/eslint-plugin-ember) from 10.6.1 to 11.11.1.

This PR substitutes the following Dependabot PR: https://github.com/qonto/ember-lottie/pull/133