### PR TITLE
fix(docs): remove unused columns in API reference table

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ ember install @qonto/ember-lottie
 
 ### Arguments
 
-| Argument      | Type     | Description                                                                                     |     | Example |
-| ------------- | -------- | ----------------------------------------------------------------------------------------------- | --- | ------- |
+| Argument      | Type     | Description                                                                                     |
+| ------------- | -------- | ----------------------------------------------------------------------------------------------- |
 | name          | string   | animation name for future reference                                                             |
 | animationData | object   | an object with the exported animation data (mandatory at least one: `animationData` or `path`)  |
 | path          | string   | the relative path to the animation object (mandatory at least one: `animationData` or `path`)   |


### PR DESCRIPTION
In this PR, we remove 2 unused columns in the API reference table in the README.
To see the changes, you can compare the [master version](https://github.com/qonto/ember-lottie/tree/main#arguments) with [this branch version](https://github.com/qonto/ember-lottie/tree/fix-api-reference-table#arguments).