### PR TITLE
Add backward compatibility with MediaQueryList.addEventListener in older browsers

### DIFF
--- a/ember-lottie/src/components/lottie.ts
+++ b/ember-lottie/src/components/lottie.ts
@@ -113,10 +113,15 @@ export default class LottieComponent extends Component<LottieSignature> {
     const speed = Ember.testing ? 0 : this.args.speed || 1;
     this.animation.setSpeed(speed);
 
-    this.mediaQuery?.addEventListener(
-      'change',
-      this.handleReducedMotionPreferenceChange,
-    );
+    if (this.mediaQuery?.addEventListener) {
+      this.mediaQuery.addEventListener(
+        'change',
+        this.handleReducedMotionPreferenceChange,
+      );
+    } else if (this.mediaQuery?.addListener) {
+      // For backward compatibility with older browsers, e.g. Safari 13
+      this.mediaQuery.addListener(this.handleReducedMotionPreferenceChange);
+    }
   }
 
   @action
@@ -130,10 +135,15 @@ export default class LottieComponent extends Component<LottieSignature> {
   willDestroy(): void {
     super.willDestroy();
 
-    this.mediaQuery?.removeEventListener(
-      'change',
-      this.handleReducedMotionPreferenceChange,
-    );
+    if (this.mediaQuery?.removeEventListener) {
+      this.mediaQuery.removeEventListener(
+        'change',
+        this.handleReducedMotionPreferenceChange,
+      );
+    } else if (this.mediaQuery?.removeListener) {
+      // For backward compatibility with older browsers, e.g. Safari 13
+      this.mediaQuery.removeListener(this.handleReducedMotionPreferenceChange);
+    }
 
     if (this.animation) {
       this.animation.destroy();

--- a/test-app/tests/integration/components/lottie-test.ts
+++ b/test-app/tests/integration/components/lottie-test.ts
@@ -107,6 +107,32 @@ module('Integration | Component | lottie', function (hooks) {
     assert.dom('[data-test-autoplay=false]').exists();
   });
 
+  test('it defaults to addListener and removeListener for browsers where MediaQueryList does not inherit form EventTarget', async function (this: TestContext, assert) {
+    const addListener = sinon.spy();
+    const removeListener = sinon.spy();
+    window.matchMedia = (): MediaQueryList => {
+      return {
+        addListener,
+        removeListener,
+        addEventListener: undefined,
+        removeEventListener: undefined,
+        matches: true,
+      } as unknown as MediaQueryList;
+    };
+
+    await render<TestContext>(hbs`
+      <Lottie
+        @path="/data.json"
+      />
+    `);
+
+    find('svg');
+    assert.true(addListener.calledOnce);
+
+    await clearRender();
+    assert.true(removeListener.calledOnce);
+  });
+
   test('it does not autoplay the animation when autoplay is false', async function (this: TestContext, assert) {
     window.matchMedia = (): MediaQueryList => {
       return {


### PR DESCRIPTION
The aim of this PR is adding backward compatibility with `MediaQueryList.addEventListener` to older browsers that don't support it, e.g. Safari versions below 14 (released on 16/09/2020), as visible in the [MDN MediaQueryList browser compatibility chart](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList#browser_compatibility).

<img src="https://github.com/qonto/ember-lottie/assets/73175085/ef270312-74a9-4b1e-bd4e-ff206e3fe9a2" width="400" />


Quoting from the [MDN MediaQueryList docs](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList#browser_compatibility): 
- > [addListener()](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener):  [...] This method exists primarily for backward compatibility; if possible, you should instead use [addEventListener()](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener) to watch for the [change](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/change_event) event.
- >[removeListener()](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/removeListener): [...] This method has been kept for backward compatibility; if possible, you should generally use [removeEventListener()](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener) to remove change notification callbacks (which should have previously been added using addEventListener()).

The root of the issue is that MediaQueryList doesn't inherit [EventTarget](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget) interface in some older browsers, leading to a `this.mediaQuery?.addEventListener is not a function` exception.

The search for a polyfill has been unfruitful. Following MDN recommendations, `addEventListener` will be kept and `addListener` will be used alongside for browsers that don't provide support.

This PR fixes issue https://github.com/qonto/ember-lottie/issues/272