### PR TITLE
feat: drop node v16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         name: Install pnpm
         with:
           pnpm-version: 8.5.1
-          node-version: 16.x
+          node-version: 18.x
 
       - name: Lint
         run: pnpm lint
@@ -45,7 +45,7 @@ jobs:
         name: Install pnpm
         with:
           pnpm-version: 8.5.1
-          node-version: 16.x
+          node-version: 18.x
           args: "--no-lockfile"
 
       - name: Run Tests
@@ -80,7 +80,7 @@ jobs:
         name: Install pnpm
         with:
           pnpm-version: 8.5.1
-          node-version: 16.x
+          node-version: 18.x
 
       - name: Run Tests
         run: pnpm try:ember ${{ matrix.try-scenario }}
@@ -107,7 +107,7 @@ jobs:
         uses: wyvox/action-setup-pnpm@v3
         with:
           pnpm-version: 8.5.1
-          node-version: 16.x
+          node-version: 18.x
           args: "--frozen-lockfile"
       - name: Update TS version on addon package
         run: pnpm add -D ${{ matrix.typescript-scenario }}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Render [lottie](https://github.com/airbnb/lottie-web) after effects animations i
 
 - Ember.js v3.28 or above
 - Ember CLI v3.28 or above
-- Node.js v14 or above
+- Node.js v18 or above
 - TypeScript v5 or above
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "release-it": "^15.11.0"
   },
   "engines": {
-    "node": "14.* || 16.* || >= 18"
+    "node": ">= 18"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -89,7 +89,7 @@
     "webpack": "^5.89.0"
   },
   "engines": {
-    "node": "14.* || 16.* || >= 18"
+    "node": ">= 18"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
# Description

In this PR, `ember-lottie` gets no more support for node v14 and v16. Node v18 becomes the earliest supported version as it is still active for now.

# Why?

Node v14 and v16 have no more active and security support. See https://endoflife.date/nodejs for more info.

The compatibility section of the package in the `README` is updated to inform node v18 or above is supported.