### PR TITLE
Set body-max-line-length to Infinity

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -4,6 +4,7 @@ module.exports = {
   extends: ["@commitlint/config-conventional"],
   rules: {
     "body-leading-blank": [2, "always"],
+    "body-max-line-length": [2, "always", Infinity],
     "footer-leading-blank": [2, "always"],
   },
 };


### PR DESCRIPTION
Since Dependabot commit messages body line lengths do not conform with `commitlint`’s current limit of 100 characters, we are modifying the rule to accept an infinite number of characters.

The reasons behind this:

- Relying on the commit body from a third party is fragile; if Dependabot updates its wording, we have to update the override
- Bumping to a fixed char limit is also not the best, could fail sometimes, we would be stuck (re-)bumping the limit every time
- Commit body is actually not used in the changelog generation, so it won’t change much in the end