### PR TITLE
Update broken lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6302,7 +6302,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.3
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.23.3)
-      '@babel/plugin-proposal-decorators': 7.23.3(@babel/core@7.23.3)
+      '@babel/plugin-proposal-decorators': 7.23.6(@babel/core@7.23.3)
       '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.23.3)
       '@babel/plugin-transform-class-static-block': 7.22.11(@babel/core@7.23.3)
       '@babel/preset-env': 7.23.2(@babel/core@7.23.3)


### PR DESCRIPTION
This PR updates the lockfile after merging Babel-related dev dependency updates.

It fixes the following warning appearing when running `pnpm install`:

```bash
WARN  Broken lockfile: no entry for '/@babel/plugin-proposal-decorators/7.23.3(@babel/core@7.23.3)' in pnpm-lock.yaml
```