### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: release
+on: workflow_dispatch
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify branch name
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "🚨 The release must start from the main branch!"
+          exit 1
+
+      - name: Configure releaser details
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+      - name: Install pnpm
+        uses: wyvox/action-setup-pnpm@v3
+        with:
+          pnpm-version: 8.5.1
+          node-version: 18.x
+          node-registry-url: "https://registry.npmjs.org"
+
+      - name: Trigger release script
+        run: pnpm run release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.release-it.js
+++ b/.release-it.js
@@ -10,10 +10,10 @@ module.exports = {
   },
   git: {
     tagName: "v${version}",
+    commitMessage: "chore: release v${version}",
   },
   github: {
     release: true,
     tokenRef: "GITHUB_AUTH",
   },
-  npm: false,
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,7 +178,7 @@ importers:
         specifier: 1.2.1
         version: 1.2.1(@glimmer/component@1.1.2)(@glint/template@1.2.1)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0)
       '@qonto/ember-lottie':
-        specifier: 1.0.0
+        specifier: 1.0.1
         version: link:../ember-lottie
       '@qonto/eslint-config-typescript':
         specifier: 1.0.0-rc.0


### PR DESCRIPTION
This PR adds a new workflow to delegate the package release to the CI.

The workflow can be dispatched only manually and will perform the following steps:
 - Check out the code, including all history for all branches and tags.
 - Verify that the workflow is triggered for the `main` branch, and abort if not.
 - Set the Git user name and email to the person (or app) that initiated the workflow.
 - Install dependencies.
 - Trigger the release script.