### PR TITLE
fix: dont pass undefined options to fetch

### DIFF
--- a/ember-lottie/src/components/lottie.ts
+++ b/ember-lottie/src/components/lottie.ts
@@ -73,10 +73,9 @@ export default class LottieComponent extends Component<LottieSignature> {
       animationData = this.args.animationData;
     } else if (this.args.path) {
       try {
-        const response = await window.fetch(
-          this.args.path,
-          this.args.fetchOptions,
-        );
+        const response = await (this.args.fetchOptions
+          ? window.fetch(this.args.path, this.args.fetchOptions)
+          : window.fetch(this.args.path));
 
         if (response.status === 404) {
           throw new NotFoundError();

--- a/test-app/tests/integration/components/lottie-test.ts
+++ b/test-app/tests/integration/components/lottie-test.ts
@@ -252,10 +252,6 @@ module('Integration | Component | lottie', function (hooks) {
       />
     `);
     const fetchArgs = fetch.getCall(0).args;
-    assert.deepEqual(
-      fetchArgs,
-      ['/data.json', undefined],
-      'fetch arguments match',
-    );
+    assert.deepEqual(fetchArgs, ['/data.json'], 'fetch arguments match');
   });
 });


### PR DESCRIPTION
We're getting Sentry errors reporting `Cannot read properties of undefined (reading 'headers')` originating from this fetch. This commit checks we have `fetchOptions` before invoking `fetch` with the `fetchOptions` otherwise only the path is used.

https://qonto.sentry.io/issues/4716260540/events/5a60659334a94c3e9e354542c5ceadf6/