### PR TITLE
chore(release-it): set npm as false on the root

### DIFF
--- a/.release-it.js
+++ b/.release-it.js
@@ -16,4 +16,5 @@ module.exports = {
     release: true,
     tokenRef: "GITHUB_AUTH",
   },
+  npm: false,
 };


### PR DESCRIPTION
Disabling `npm` on the root configuration for `release-it` should help us solve [this problem](https://github.com/qonto/ember-lottie/actions/runs/7349402643/job/20009262612#step:6:23), where multiple processes (`release-it` itself + `@release-it/workspaces`) try to bump the `npm` version by running `npm version` ending up in conflicts.