### PR TITLE
chore(release-it): remove tokenRef from configuration

### DIFF
--- a/.release-it.js
+++ b/.release-it.js
@@ -14,7 +14,6 @@ module.exports = {
   },
   github: {
     release: true,
-    tokenRef: "GITHUB_AUTH",
   },
   npm: false,
   hooks: {


### PR DESCRIPTION
We couldn't create the previous GitHub release through the `Release` action, because we had the wrong `tokenRef` inside the release-it conf. By removing it, we'll use the default one - that's the one correctly set.