### PR TITLE
chore(release-it): add pnpm install hook in the conf

### DIFF
--- a/.release-it.js
+++ b/.release-it.js
@@ -17,4 +17,7 @@ module.exports = {
     tokenRef: "GITHUB_AUTH",
   },
   npm: false,
+  hooks: {
+    "after:bump": "pnpm i",
+  },
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,7 +178,7 @@ importers:
         specifier: 1.2.1
         version: 1.2.1(@glimmer/component@1.1.2)(@glint/template@1.2.1)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0)
       '@qonto/ember-lottie':
-        specifier: 1.1.0
+        specifier: 1.1.1
         version: link:../ember-lottie
       '@qonto/eslint-config-typescript':
         specifier: 1.0.0-rc.0


### PR DESCRIPTION
Adding the pnpm install hook to the conf to avoid [the outdated pnpm-lockfile problem](https://github.com/qonto/ember-lottie/actions/runs/7357391404/job/20028954115?pr=357#step:3:134).