### PR TITLE
Use latest instead of next in typecheck job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
           - typescript@5.0
           - typescript@5.1
           - typescript@5.2
-          - typescript@next
+          - typescript@latest
 
     steps:
       - name: Checkout


### PR DESCRIPTION
The `@next` tag is experimental and currently breaks type checking in CI. `@latest` means the latest **stable** version, which is enough for future proofing types.